### PR TITLE
Running in Crystal 1x & readme for running in local environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ $ docker run --rm -it -e HOST=nuntium-stg.instedd.org -e ACCOUNT=manas -e CHANNE
 Example using variables: 
 ```docker run --rm -it -e HOST=nuntium-stg.instedd.org -e ACCOUNT=email@email.com -e CHANNEL_NAME=my_channel -e CHANNEL_PASSWORD=password -e DELAY_REPLY_MIN_SECONDS=20 -e DELAY_REPLY_MAX_SECONDS=25 -e DELAY_REPLY_PERCENT=1 instedd/lgwsim```
 
+## Usage in you local environment
+
+If you are running Nuntium in your local environment, follow the  steps above to create a QST server. Your `config.yml` should probably have these two parameters as follows:
+
+`host: web.nuntium.lvh.me`
+`port: 80`
+
 ## Behaviour
 
 For each message received, if a reply is sent, it will be according to de following rules

--- a/shard.yml
+++ b/shard.yml
@@ -4,6 +4,12 @@ version: 0.1.0
 authors:
   - Ary Borenszweig <aborenszweig@manas.com.ar>
 
+dependencies:
+  yaml_mapping:
+    github: crystal-lang/yaml_mapping.cr
+  json_mapping:
+    github: crystal-lang/json_mapping.cr
+
 targets:
   lgwsim:
     main: src/lgwsim.cr

--- a/src/config.cr
+++ b/src/config.cr
@@ -1,4 +1,5 @@
 require "yaml"
+require "yaml_mapping"
 
 class Lgwsim::Config
   FILENAME = "config.yml"

--- a/src/message.cr
+++ b/src/message.cr
@@ -1,4 +1,5 @@
 require "json"
+require "json_mapping"
 require "xml"
 
 record Lgwsim::Message,


### PR DESCRIPTION
Added shards to recognize `YAML.mapping` & `JSON.mapping` methods that make the code work in crystal 1.x. 

Added a `README.md` section to run in local environments (since the `PORT` was not detailed in other places in the readme, and it takes the SSL as default was a little misleading for running locally). 