### PR TITLE
Slow mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The following environment variables controls other aspects of the behavior
 
 | Variable | Default | Description |
 |-|-|-|
-| `SLEEP_SECONDS` | 10 | How much time to wait between fetches from the QST server |
+| `SLEEP_SECONDS` | 10 | How much time to wait between fetches from the QST server (Nuntium will mark the channel as down if it's not polled every 2 minutes) |
 | `NO_REPLY_PERCENT` | 0.2 | Percent of respondents that never reply |
 | `DELAY_REPLY_PERCENT` | 0.2 | Percent of respondents that have a delay in their reply |
 | `DELAY_REPLY_MIN_SECONDS` | 0 | Of the above, minimum time in seconds of that delay (min..max) |

--- a/README.md
+++ b/README.md
@@ -78,4 +78,4 @@ The following environment variables controls other aspects of the behavior
 | `DELAY_REPLY_MAX_SECONDS` | 60 | Of the above, maximum time in seconds of that delay (min..max) |
 | `INCORRECT_REPLY_PERCENT` | 0.2 | Percent of respondents that reply an incorrect answer |
 | `STICKY_RESPONDENTS` | true | If true, once a respondent replies, it will always reply |
-
+| `INCOMING_BATCH_SIZE` | 100 | How many incoming messages to fetch at once |

--- a/config.yml
+++ b/config.yml
@@ -25,3 +25,5 @@ incorrect_reply_percent: 0.2
 # If true, once a respondent replies, it will always reply
 sticky_respondents: true
 
+# How many incoming messages to fetch at once
+incoming_batch_size: 100

--- a/src/config.cr
+++ b/src/config.cr
@@ -18,6 +18,7 @@ class Lgwsim::Config
     delay_reply_max_seconds: Int32,
     incorrect_reply_percent: Float64,
     sticky_respondents: Bool,
+    incoming_batch_size: Int32,
   )
 
   def initialize
@@ -34,6 +35,7 @@ class Lgwsim::Config
     @delay_reply_max_seconds = Config.int_env("DELAY_REPLY_MAX_SECONDS")
     @incorrect_reply_percent = Config.float_env("INCORRECT_REPLY_PERCENT")
     @sticky_respondents = Config.string_env("STICKY_RESPONDENTS") == "true"
+    @incoming_batch_size = Config.int_env("INCOMING_BATCH_SIZE")
   end
 
   protected def self.string_env(var_name)

--- a/src/qst_client.cr
+++ b/src/qst_client.cr
@@ -46,7 +46,7 @@ class Lgwsim::QSTClient
     headers = HTTP::Headers.new
     headers["If-None-Match"] = etag if etag
 
-    response = @client.get("/#{@account}/qst/outgoing.xml?max=#{@incoming_batch_size.to_s}", headers: headers)
+    response = @client.get("/#{@account}/qst/outgoing.xml?max=#{@incoming_batch_size}", headers: headers)
 
     # Check Not-Modified
     if response.status_code == 304

--- a/src/qst_client.cr
+++ b/src/qst_client.cr
@@ -10,7 +10,8 @@ class Lgwsim::QSTClient
                  *,
                  account : String,
                  channel_name : String,
-                 channel_password : String)
+                 channel_password : String,
+                 @incoming_batch_size : Int32)
     @account = URI.encode_www_form(account)
     @client = HTTP::Client.new(host: host, port: port, tls: tls)
     @client.basic_auth(channel_name, channel_password)
@@ -45,7 +46,7 @@ class Lgwsim::QSTClient
     headers = HTTP::Headers.new
     headers["If-None-Match"] = etag if etag
 
-    response = @client.get("/#{@account}/qst/outgoing.xml?max=100", headers: headers)
+    response = @client.get("/#{@account}/qst/outgoing.xml?max=#{@incoming_batch_size.to_s}", headers: headers)
 
     # Check Not-Modified
     if response.status_code == 304

--- a/src/simulator.cr
+++ b/src/simulator.cr
@@ -11,7 +11,8 @@ class Lgwsim::Simulator
       tls: @config.tls,
       account: @config.account,
       channel_name: @config.channel_name,
-      channel_password: @config.channel_password)
+      channel_password: @config.channel_password,
+      incoming_batch_size: @config.incoming_batch_size)
   end
 
   def run

--- a/src/simulator.cr
+++ b/src/simulator.cr
@@ -29,9 +29,7 @@ class Lgwsim::Simulator
 
       send_outgoing_messages
 
-      if messages.empty?
-        sleep @config.sleep_seconds
-      end
+      sleep @config.sleep_seconds
     end
   end
 


### PR DESCRIPTION
Allow to simulate slow providers by tweaking how many messages to process at once, and to honor the sleep delays even if there are pending messages in the channel.